### PR TITLE
Set default category value for administration forms

### DIFF
--- a/invenio_banners/administration/banners.py
+++ b/invenio_banners/administration/banners.py
@@ -117,6 +117,7 @@ class BannerEditView(AdminResourceEditView):
                 {"title_l10n": "Warning", "id": "warning"},
                 {"title_l10n": "Other", "id": "other"},
             ],
+            "placeholder": "Select a category",
         },
         "active": {
             "order": 6,
@@ -200,7 +201,7 @@ class BannerCreateView(AdminResourceCreateView):
                 {"title_l10n": "Warning", "id": "warning"},
                 {"title_l10n": "Other", "id": "other"},
             ],
-            "placeholder": "Info",
+            "placeholder": "Select a category",
         },
         "active": {
             "order": 6,

--- a/invenio_banners/services/schemas.py
+++ b/invenio_banners/services/schemas.py
@@ -19,7 +19,7 @@ class BannerSchema(BaseRecordSchema):
 
     message = fields.String(required=True)
     url_path = fields.String(allow_none=True)
-    category = fields.String(required=True)
+    category = fields.String(required=True, metadata={"default": "info"})
     start_datetime = fields.DateTime(
         required=True,
         metadata={"default": datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S")},


### PR DESCRIPTION
### Description

Partially fixes issue https://github.com/inveniosoftware/invenio-banners/issues/26 by setting a default value of required category form field.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
