### PR TITLE
feat(administration): use html editor for message

### DIFF
--- a/invenio_banners/services/schemas.py
+++ b/invenio_banners/services/schemas.py
@@ -11,13 +11,13 @@ from datetime import datetime, timezone
 
 from invenio_records_resources.services.records.schema import BaseRecordSchema
 from marshmallow import fields, pre_load
-from marshmallow_utils.fields import TZDateTime
+from marshmallow_utils.fields import SanitizedHTML, TZDateTime
 
 
 class BannerSchema(BaseRecordSchema):
     """Schema for banners."""
 
-    message = fields.String(required=True)
+    message = SanitizedHTML(required=True)
     url_path = fields.String(allow_none=True)
     category = fields.String(required=True, metadata={"default": "info"})
     start_datetime = fields.DateTime(

--- a/tests/resources/test_resources.py
+++ b/tests/resources/test_resources.py
@@ -56,6 +56,14 @@ banners = {
             "%Y-%m-%d %H:%M:%S"
         ),
     },
+    "html_banner": {
+        "message": '<h1>HTML aware banner.</h1>.\n \'<p class="test">paragraph<br /></p><script '
+        "type=\"text/javascript\">alert('You won!')</script>",
+        "url_path": "/html_banner",
+        "category": "warning",
+        "active": True,
+        "start_datetime": datetime(2022, 7, 20, 20, 0, 0).strftime("%Y-%m-%d %H:%M:%S"),
+    },
 }
 
 
@@ -376,3 +384,14 @@ def test_search_banner_empty_list(client, user):
     result = banners["hits"]
     assert len(result["hits"]) == 0
     assert result["total"] == 0
+
+
+def test_html_banner(client, admin, headers):
+    banner_data = banners["html_banner"]
+    admin.login(client)
+
+    banner = _create_banner(client, banner_data, headers, 201).json
+    assert (
+        banner["message"]
+        == "<h1>HTML aware banner.</h1>.\n '<p>paragraph<br></p>alert('You won!')"
+    )


### PR DESCRIPTION
### Description

This PR uses Sanitized HTML WYSIWYG editor instead of raw text input for banner message content to make banner administration more user friendly.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Frontend**

- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
