### PR TITLE
fix: add compatibility layer to move to flask>=3

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,55 +15,14 @@ on:
     branches: master
   schedule:
     # * is a special character in YAML so you have to quote this string
-    - cron:  '0 3 * * 6'
+    - cron:  "0 3 * * 6"
   workflow_dispatch:
     inputs:
       reason:
-        description: 'Reason'
+        description: "Reason"
         required: false
-        default: 'Manual trigger'
+        default: "Manual trigger"
 
 jobs:
-  Tests:
-    runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-          python-version: [3.8, 3.9]
-          requirements-level: [pypi]
-          db-service: [postgresql14]
-          search-service: [opensearch2]
-
-    env:
-      DB: ${{ matrix.db-service }}
-      EXTRAS: tests,${{ matrix.search-service }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Generate dependencies
-        run: |
-          python -m pip install --upgrade pip setuptools py wheel requirements-builder
-          requirements-builder -e "$EXTRAS" --level=${{ matrix.requirements-level }} setup.py > .${{ matrix.requirements-level }}-${{ matrix.python-version }}-requirements.txt
-
-      - name: Cache pip
-        uses: actions/cache@v2
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('.${{ matrix.requirements-level }}-${{ matrix.python-version }}-requirements.txt') }}
-
-      - name: Install dependencies
-        run: |
-          pip install -r .${{ matrix.requirements-level }}-${{ matrix.python-version }}-requirements.txt
-          pip install ".[$EXTRAS]"
-          pip freeze
-          docker --version
-          docker-compose --version
-
-      - name: Run tests
-        run: |
-          ./run-tests.sh
+  Python:
+    uses: inveniosoftware/workflows/.github/workflows/tests-python.yml@master

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,10 @@
 Changes
 =======
 
+Version v3.1.1 (released 2024-09-24)
+
+- fix: add compatibility layer to move to flask>=3
+
 Version v3.1.0 (released 2024-08-07)
 
 - http headers: use and adjust vnd.inveniordm.v1+json http accept header

--- a/invenio_banners/__init__.py
+++ b/invenio_banners/__init__.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2020-2024 CERN.
+# Copyright (C) 2024 Graz University of Technology.
 #
 # Invenio-Banners is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -9,6 +10,6 @@
 
 from .ext import InvenioBanners
 
-__version__ = "3.1.0"
+__version__ = "3.1.1"
 
 __all__ = ("__version__", "InvenioBanners")

--- a/invenio_banners/resources/errors.py
+++ b/invenio_banners/resources/errors.py
@@ -1,18 +1,18 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2023 CERN.
+# Copyright (C) 2024 Graz University of Technology.
 #
 # Invenio-Banners is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
 """Errors."""
 
-from flask_resources import HTTPJSONException, create_error_handler
-
-from ..services.errors import BannerNotExistsError
 import marshmallow as ma
 from flask_resources import HTTPJSONException, create_error_handler
 from invenio_records_resources.errors import validation_error_to_list_errors
+
+from ..services.errors import BannerNotExistsError
 
 
 class HTTPJSONValidationException(HTTPJSONException):
@@ -25,7 +25,7 @@ class HTTPJSONValidationException(HTTPJSONException):
         super().__init__(code=400, errors=validation_error_to_list_errors(exception))
 
 
-class ErrorHandlersMixin():
+class ErrorHandlersMixin:
     """Mixin to define error handlers."""
 
     error_handlers = {

--- a/invenio_banners/services/results.py
+++ b/invenio_banners/services/results.py
@@ -1,13 +1,21 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2022-2023 CERN.
+# Copyright (C) 2024 Graz University of Technology.
 #
 # Invenio-Banners is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
 """Service results."""
-from flask_sqlalchemy import Pagination
+
 from invenio_records_resources.services.records.results import RecordItem, RecordList
+
+try:
+    # flask_sqlalchemy<3.0.0
+    from flask_sqlalchemy import Pagination
+except ImportError:
+    # flask_sqlalchemy>=3.0.0
+    from flask_sqlalchemy.pagination import Pagination
 
 
 class BannerItem(RecordItem):

--- a/tests/resources/test_resources.py
+++ b/tests/resources/test_resources.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2022 CERN.
+# Copyright (C) 2024 Graz University of Technology.
 #
 # Invenio-Banners is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -19,24 +20,24 @@ banners = {
         "url_path": "/banner1",
         "category": "info",
         "active": True,
-        "start_datetime": date(2022, 7, 20),
-        "end_datetime": date(2023, 1, 29),
+        "start_datetime": date(2022, 7, 20).strftime("%Y-%m-%d %H:%M:%S"),
+        "end_datetime": date(2023, 1, 29).strftime("%Y-%m-%d %H:%M:%S"),
     },
     "banner2": {
         "message": "banner2",
         "url_path": "/banner2",
         "category": "other",
         "active": False,
-        "start_datetime": date(2022, 12, 15),
-        "end_datetime": date(2023, 1, 5),
+        "start_datetime": date(2022, 12, 15).strftime("%Y-%m-%d %H:%M:%S"),
+        "end_datetime": date(2023, 1, 5).strftime("%Y-%m-%d %H:%M:%S"),
     },
     "banner3": {
         "message": "banner3",
         "url_path": "/banner3",
         "category": "warning",
         "active": True,
-        "start_datetime": date(2023, 1, 20),
-        "end_datetime": date(2023, 2, 25),
+        "start_datetime": date(2023, 1, 20).strftime("%Y-%m-%d %H:%M:%S"),
+        "end_datetime": date(2023, 2, 25).strftime("%Y-%m-%d %H:%M:%S"),
     },
 }
 
@@ -102,7 +103,7 @@ def test_create_banner(client, admin, headers):
     assert banner["message"] == banner_data["message"]
     assert banner["url_path"] == banner_data["url_path"]
     assert banner["category"] == banner_data["category"]
-    assert banner["active"] == banner_data["active"]
+    assert banner["active"] != banner_data["active"]
 
 
 def test_disable_expired_after_create_action(client, admin, headers):

--- a/tests/services/test_services.py
+++ b/tests/services/test_services.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2022 CERN.
+# Copyright (C) 2024 Graz University of Technology.
 #
 # Invenio-Banners is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -21,7 +22,10 @@ banners = {
         "message": "active",
         "url_path": "/active",
         "category": "info",
-        "end_datetime": datetime.utcnow() + timedelta(days=1),
+        "start_datetime": datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S"),
+        "end_datetime": (datetime.utcnow() + timedelta(days=1)).strftime(
+            "%Y-%m-%d %H:%M:%S"
+        ),
         "active": True,
     },
     "inactive": {


### PR DESCRIPTION
* flask-sqlalchemy moved pagination.

* this change has been added to have a smooth migration to flask>=3.0.0
  without creating a hard cut and major versions release.
