### PR TITLE
Using lazy_gettext in boot-time translations

### DIFF
--- a/invenio_banners/administration/banners.py
+++ b/invenio_banners/administration/banners.py
@@ -102,9 +102,9 @@ common_form_fields = {
             "`Other` option displays a gray banner."
         ),
         "options": [
-            {"title_l10n": "Info", "id": "info"},
-            {"title_l10n": "Warning", "id": "warning"},
-            {"title_l10n": "Other", "id": "other"},
+            {"title_l10n": _("Info"), "id": "info"},
+            {"title_l10n": _("Warning"), "id": "warning"},
+            {"title_l10n": _("Other"), "id": "other"},
         ],
         "placeholder": "Select a category",
     },
@@ -134,8 +134,8 @@ class BannerEditView(AdminResourceEditView):
 
     form_fields = {
         **common_form_fields,
-        "created": {"order": 7},
-        "updated": {"order": 8},
+        "created": {"text": _("Created"), "order": 7},
+        "updated": {"text": _("Updated"), "order": 8},
     }
 
 

--- a/invenio_banners/services/config.py
+++ b/invenio_banners/services/config.py
@@ -7,7 +7,7 @@
 
 """Banners Service configuration."""
 
-from invenio_i18n import gettext as _
+from invenio_i18n import lazy_gettext as _
 from invenio_records_resources.services import (
     EndpointLink,
     RecordServiceConfig,

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -20,6 +20,7 @@ trap cleanup EXIT
 python -m check_manifest --ignore ".*-requirements.txt"
 python -m sphinx.cmd.build -qnNW docs docs/_build/html
 eval "$(docker-services-cli up --db ${DB:-postgresql} --search ${SEARCH:-opensearch} --env)"
+python setup.py compile_catalog
 python -m pytest
 tests_exit_code=$?
 python -m sphinx.cmd.build -qnNW -b doctest docs docs/_build/doctest

--- a/tests/ui/conftest.py
+++ b/tests/ui/conftest.py
@@ -1,0 +1,103 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2024 CESNET z.s.p.o.
+#
+# Invenio-Banners is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""UI tests configuration.
+
+Note: need to call python setup.py compile_catalog to compile the translations before
+running the tests.
+"""
+import json
+from pathlib import Path
+
+import pytest
+from flask_security import login_user
+from invenio_accounts.testutils import login_user_via_session
+from invenio_app.factory import create_app as _create_app
+from invenio_i18n import lazy_gettext as _
+
+
+@pytest.fixture(scope="module")
+def create_app(instance_path):
+    """Application factory fixture."""
+    return _create_app
+
+
+@pytest.fixture(scope="module")
+def app_config(app_config):
+    """Override pytest-invenio app_config fixture.
+
+    Set languages for the app.
+    """
+    app_config["I18N_LANGUAGES"] = [
+        ("cs", _("Czech")),
+    ]
+    return app_config
+
+
+@pytest.fixture()
+def admin_identity(admin):
+    """Identity of the admin user."""
+    return admin.identity
+
+
+@pytest.fixture()
+def admin_client(db, client, admin):
+    """Log in a user to the client."""
+
+    login_user(admin.user, remember=True)
+    login_user_via_session(client, email=admin.user.email)
+
+    return client
+
+
+def add_to_manifest(manifest, filename):
+    manifest.setdefault("assets", {})[filename] = {"publicPath": filename}
+    filename_without_ext = filename.rsplit(".", 1)[0]
+    manifest.setdefault("chunks", {}).setdefault(filename_without_ext, []).append(
+        filename
+    )
+
+
+@pytest.fixture()
+def fake_manifest(app, instance_path):
+    app.static_folder = str(Path(instance_path) / "static")
+
+    manifest_path = Path(instance_path) / "static" / "dist" / "manifest.json"
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+
+    manifest = {
+        "status": "done",
+        "publicPath": "/static/dist/",
+    }
+    add_to_manifest(manifest, "base.js")
+    add_to_manifest(manifest, "base-admin-theme.js")
+
+    add_to_manifest(manifest, "i18n_app.js")
+    add_to_manifest(manifest, "invenio-administration-details.js")
+    add_to_manifest(manifest, "invenio-administration-search.js")
+
+    add_to_manifest(manifest, "theme.css")
+    add_to_manifest(manifest, "theme.js")
+
+    manifest_path.write_text(json.dumps(manifest))
+    return manifest_path
+
+
+@pytest.fixture()
+def clear_babel_context():
+
+    # force babel reinitialization when language is switched
+    def _clear_babel_context():
+        try:
+            from flask import g
+            from flask_babel import SimpleNamespace
+
+            g._flask_babel = SimpleNamespace()
+        except ImportError:
+            return
+
+    return _clear_babel_context

--- a/tests/ui/conftest.py
+++ b/tests/ui/conftest.py
@@ -10,6 +10,7 @@
 Note: need to call python setup.py compile_catalog to compile the translations before
 running the tests.
 """
+
 import json
 from pathlib import Path
 
@@ -47,7 +48,6 @@ def admin_identity(admin):
 @pytest.fixture()
 def admin_client(db, client, admin):
     """Log in a user to the client."""
-
     login_user(admin.user, remember=True)
     login_user_via_session(client, email=admin.user.email)
 
@@ -55,6 +55,7 @@ def admin_client(db, client, admin):
 
 
 def add_to_manifest(manifest, filename):
+    """Add a file to the manifest."""
     manifest.setdefault("assets", {})[filename] = {"publicPath": filename}
     filename_without_ext = filename.rsplit(".", 1)[0]
     manifest.setdefault("chunks", {}).setdefault(filename_without_ext, []).append(
@@ -64,6 +65,7 @@ def add_to_manifest(manifest, filename):
 
 @pytest.fixture()
 def fake_manifest(app, instance_path):
+    """Create a fake manifest.json file for testing."""
     app.static_folder = str(Path(instance_path) / "static")
 
     manifest_path = Path(instance_path) / "static" / "dist" / "manifest.json"
@@ -89,8 +91,8 @@ def fake_manifest(app, instance_path):
 
 @pytest.fixture()
 def clear_babel_context():
+    """Clear the babel context to force reinitialization when language is switched."""
 
-    # force babel reinitialization when language is switched
     def _clear_babel_context():
         try:
             from flask import g

--- a/tests/ui/test_i18n_administration.py
+++ b/tests/ui/test_i18n_administration.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2024 CESNET z.s.p.o.
+#
+# Invenio-Banners is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Test the i18n of the administration interface.
+
+Note: this does not test the actual translation of the messages, but rather that the
+translation kicks in and that some of the labels are localized - so that we know that
+the lazy_gettext is working.
+"""
+
+from datetime import datetime, timedelta
+
+from invenio_banners.proxies import current_banners_service as service
+
+
+def test_list_is_localized(app, admin_client, fake_manifest, clear_babel_context):
+    """Test that the administration page is localized and that the labels are translated."""
+
+    clear_babel_context()
+    resp = admin_client.get("/administration/banners")
+    assert resp.status_code == 200
+    assert resp.content_type == "text/html; charset=utf-8"
+    # check that the string "Active" is in the response twice (sort order, column number)
+    assert len(resp.text.split('"Active"')) == 3
+
+    clear_babel_context()
+    resp = admin_client.get(
+        "/administration/banners", headers=[("Accept-Language", "cs")]
+    )
+    assert resp.status_code == 200
+    assert resp.content_type == "text/html; charset=utf-8"
+    assert '<html lang="cs"' in resp.text
+
+    # checks both sort order and table column name
+    assert "Active" not in resp.text
+
+
+def test_detail_is_localized(
+    app, admin, admin_client, fake_manifest, clear_babel_context
+):
+    """Test that the administration detail page is localized and that the labels are translated."""
+
+    active_banner = {
+        "message": "active",
+        "url_path": "/active",
+        "category": "info",
+        "start_datetime": (datetime.now() - timedelta(days=1)).isoformat(),
+        "end_datetime": (datetime.now() + timedelta(days=1)).isoformat(),
+        "active": True,
+    }
+
+    banner_id = service.create(admin.identity, active_banner)["id"]
+
+    clear_babel_context()
+    resp = admin_client.get(f"/administration/banners/{banner_id}")
+    assert resp.status_code == 200
+    assert resp.content_type == "text/html; charset=utf-8"
+    assert '"Active"' in resp.text
+
+    clear_babel_context()
+    resp = admin_client.get(
+        f"/administration/banners/{banner_id}", headers=[("Accept-Language", "cs")]
+    )
+    assert resp.status_code == 200
+    assert resp.content_type == "text/html; charset=utf-8"
+    assert '<html lang="cs"' in resp.text
+
+    # checks both sort order and table column name
+    assert "Active" not in resp.text


### PR DESCRIPTION
### Description

This pull request fixes premature evaluation of i18n strings inside static fields. `gettext` call, that causes
the evaluation to be performed at boot time, was replaced with `gettext_lazy` that is performed at 
request time. This fixes sort options not being translated when language is changed.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Frontend**

- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
