### PR TITLE
templates: pass ui classes through macro parameters

### DIFF
--- a/invenio_banners/templates/semantic-ui/invenio_banners/banner.html
+++ b/invenio_banners/templates/semantic-ui/invenio_banners/banner.html
@@ -7,12 +7,15 @@
   under the terms of the MIT License; see LICENSE file for more details.
 #}
 
-{%- macro banner() -%}
+{%- macro banner(ui_classes) -%}
   {%- block banner %}
     {%- set banners = get_active_banners() %}
+    {% if not ui_classes %}
+      {% set ui_classes = "top attached m-0" %}
+    {% endif %}
     {% if banners %}
       {% for banner in banners %}
-        <div class="{{ banner.category|style_banner_category }}">
+        <div class="ui {{ banner.category|style_banner_category }} message {{ ui_classes }} inv-banner" id="banner-{{ banner.id }}">
           <div class="ui container">
               {{ banner.message|safe }}
           </div>

--- a/invenio_banners/utils.py
+++ b/invenio_banners/utils.py
@@ -20,7 +20,7 @@ def get_active_banners_for_request():
 
 def style_category(category):
     """Return predefined Semantic-UI classes for each banner category."""
-    style_class = "ui {} flashed top attached manage m-0 message"
+    style_class = "{}"
     if category == "warning":
         style_class = style_class.format("warning")
     elif category == "other":

--- a/tests/test_macro.py
+++ b/tests/test_macro.py
@@ -51,19 +51,18 @@ def test_jinja_macro(app, db):
     # add one banner
     EXPECTED_MSG = "Test banner info message"
     EXPECTED_CATEGORY = "info"
-    EXPECTED_STYLE = "ui info flashed top attached manage m-0 message"
+    EXPECTED_STYLE = "ui info message top attached m-0 inv-banner"
     banner = _create_banner(EXPECTED_MSG, EXPECTED_CATEGORY)
     style = style_category(banner.category)
-
     html = template.render()
     assert EXPECTED_MSG in html
-    assert style.endswith(EXPECTED_STYLE)
-    assert style in html
+    assert style.endswith(EXPECTED_CATEGORY)
+    assert EXPECTED_STYLE in html
 
     # change message and category
     EXPECTED_MSG = "Test banner warning message"
     EXPECTED_CATEGORY = "warning"
-    EXPECTED_STYLE = "ui warning flashed top attached manage m-0 message"
+    EXPECTED_STYLE = "ui warning message top attached m-0 inv-banner"
 
     banner.message = EXPECTED_MSG
     banner.category = EXPECTED_CATEGORY
@@ -73,5 +72,5 @@ def test_jinja_macro(app, db):
 
     html = template.render()
     assert EXPECTED_MSG in html
-    assert style.endswith(EXPECTED_STYLE)
-    assert style in html
+    assert style.endswith(EXPECTED_CATEGORY)
+    assert EXPECTED_STYLE in html


### PR DESCRIPTION
* closes https://github.com/CERNDocumentServer/cds-rdm/issues/324
* change is backwards compatible

## Attention (for CDS-RDM)
1. we need to backport it to v3