### PR TITLE
remove unused variable `request_extra_args`

### DIFF
--- a/invenio_banners/resources/config.py
+++ b/invenio_banners/resources/config.py
@@ -38,11 +38,6 @@ class BannerResourceConfig(RecordResourceConfig):
         "banner_id": ma.fields.String(),
     }
 
-    request_extra_args = {
-        "active": ma.fields.Boolean(),
-        "url_path": ma.fields.String(),
-    }
-
     request_search_args = BannerServerSearchRequestArgsSchema
 
     request_body_parsers = {"application/json": RequestBodyParser(JSONDeserializer())}


### PR DESCRIPTION
the variable is unused and might be a leftover from a previous attempt to implement what was achieved [here](https://github.com/inveniosoftware/invenio-banners/pull/58)