### PR TITLE
fix(tests): alembic migration test

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,12 @@
 Changes
 =======
 
+Version v7.0.0 (released 2026-05-29)
+
+- chore(setup): bump dependencies
+- fix(tests): alembic migration test
+- ui(translations): mark string as translatable
+
 Version v6.0.0 (released 2026-01-30)
 
 - chore(setup): bump dependencies

--- a/invenio_banners/__init__.py
+++ b/invenio_banners/__init__.py
@@ -11,6 +11,6 @@
 
 from .ext import InvenioBanners
 
-__version__ = "6.0.0"
+__version__ = "7.0.0"
 
 __all__ = ("__version__", "InvenioBanners")

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,8 +28,8 @@ python_requires = >=3.7
 zip_safe = False
 install_requires =
     invenio-i18n>=3.0.0,<4.0.0
-    invenio-administration>=5.0.0,<6.0.0
-    invenio-records-resources>=9.0.0,<10.0.0
+    invenio-administration>=6.0.0,<7.0.0
+    invenio-records-resources>=10.0.0,<11.0.0
 
 [options.extras_require]
 tests =

--- a/tests/test_alembic.py
+++ b/tests/test_alembic.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2023 CERN.
+# Copyright (C) 2024 Graz University of Technology.
+# Copyright (C) 2026 CESNET z.s.p.o.
+#
+# Invenio-banners is free software; you can redistribute it and/or modify
+# it under the terms of the MIT License; see LICENSE file for more details.
+"""Test invenio-banners alembic."""
+
+import pytest
+from invenio_db.utils import alembic_test_context, drop_alembic_version_table
+
+
+def test_alembic(app, db, extra_entry_points):
+    """Test alembic recipes."""
+    ext = app.extensions["invenio-db"]
+
+    if db.engine.name == "sqlite":
+        raise pytest.skip("Upgrades are not supported on SQLite.")
+
+    app.config["ALEMBIC_CONTEXT"] = alembic_test_context()
+
+    # Check that this package's SQLAlchemy models have been properly registered
+    tables = [x for x in db.metadata.tables]
+    assert "banners" in tables
+
+    # Check that Alembic agrees that there's no further tables to create.
+    assert ext.alembic.compare_metadata() == []
+
+    # Drop everything and recreate tables all with Alembic
+    db.drop_all()
+    drop_alembic_version_table()
+    ext.alembic.upgrade()
+
+    assert ext.alembic.compare_metadata() == []
+
+    ext.alembic.downgrade("dbdbc1b19cf2")
+    ext.alembic.upgrade()
+
+    assert ext.alembic.compare_metadata() == []
+
+    drop_alembic_version_table()


### PR DESCRIPTION
### Description

This PR adds a simple test for alembic migrations to make sure they are not forgotten when db tables are changed.

Note: needs https://github.com/inveniosoftware/invenio-accounts/pull/551 to pass

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
