### PR TITLE
refactor(date): replace arrow with pendulum

### DIFF
--- a/invenio_banners/services/service.py
+++ b/invenio_banners/services/service.py
@@ -4,7 +4,7 @@
 
 """Banner Service API."""
 
-import arrow
+import pendulum
 from invenio_db.uow import unit_of_work
 from invenio_records_resources.services import RecordService
 from invenio_records_resources.services.base import LinksTemplate
@@ -159,7 +159,7 @@ class BannerService(RecordService):
 
     def _validate_datetime(self, value):
         try:
-            date_value = arrow.get(value).date()
+            date_value = pendulum.parse(value).date()
         except ValueError:
             return None
         return date_value

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
   "invenio-administration>=7.0.0,<8.0.0",
   "invenio-i18n>=4.0.0,<5.0.0",
   "invenio-records-resources>=11.0.0,<12.0.0",
+  "pendulum>=3.2.0",
 ]
 dynamic = ["version"]
 

--- a/tests/resources/test_resources.py
+++ b/tests/resources/test_resources.py
@@ -311,7 +311,7 @@ def test_search_banner_with_query_string(client, user):
     assert result_hits["hits"][0]["message"] == "banner3"
 
     # filter by datetime(start_datetime)
-    query_string = {"q": "2023-1-20"}
+    query_string = {"q": "2023-01-20"}
     banners_result = _search_banners(client, 200, query_string).json
 
     result_hits = banners_result["hits"]


### PR DESCRIPTION
* [pendulum](https://pypi.org/project/pendulum/) is always timezone-aware with UTC by default
* in some experiments, it has a slightly better performance

```python
Python 3.14.6 (main, Jun 15 2026, 11:36:54) [GCC 16.1.1 20260430]
Type 'copyright', 'credits' or 'license' for more information
IPython 9.12.0 -- An enhanced Interactive Python. Type '?' for help.
Tip: You can find how to type a LaTeX symbol by back-completing it, eg `\θ<tab>` will expand to `\theta`.

In [1]: import arrow

In [2]: import pendulum

In [3]: %time pendulum.parse("2026-01-01 10:00:00")
CPU times: user 38 μs, sys: 6 μs, total: 44 μs
Wall time: 47.4 μs
Out[3]: DateTime(2026, 1, 1, 10, 0, 0, tzinfo=Timezone('UTC'))

In [4]: %time pendulum.parse("2026-01-01 10:00:00").date()
CPU times: user 40 μs, sys: 6 μs, total: 46 μs
Wall time: 48.2 μs
Out[4]: Date(2026, 1, 1)

In [5]: %time arrow.get("2026-01-01 10:00:00")
CPU times: user 906 μs, sys: 0 ns, total: 906 μs
Wall time: 915 μs
Out[5]: <Arrow [2026-01-01T10:00:00+00:00]>

In [6]: %time arrow.get("2026-01-01 10:00:00").date()
CPU times: user 95 μs, sys: 14 μs, total: 109 μs
Wall time: 112 μs
Out[6]: datetime.date(2026, 1, 1)
```